### PR TITLE
typo in ps command

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Eclipse JNoSQL is a Java framework that streamlines the integration of Java appl
 `docker-compose -f docker-compose.yml down`
 
 ####  List services
-`docker-compose -f ft-compose.yml ps`
+`docker-compose -f docker-compose.yml ps`
 
 
 

--- a/key-value/README.md
+++ b/key-value/README.md
@@ -67,9 +67,9 @@ This class creates and persist into Diana-redis one user with two telephone numb
 	```
 3. Run the project via Maven 
 	```
-	mvn exec:java -Dexec.mainClass="org.jnosql.demo.key-value.App"
+	mvn exec:java -Dexec.mainClass="org.jnosql.demo.key.App"
 	
-	mvn exec:java -Dexec.mainClass="org.jnosql.demo.key-value.App2"
+	mvn exec:java -Dexec.mainClass="org.jnosql.demo.key.App2"
 	```
 	
 ## Time to practice


### PR DESCRIPTION
1) The ps command didn't work for compose because the yml file name was different than we pulled. It needed to match (be docker-compose.yml)
2) In the codebase the package is org.jnosql.demo.key. Not org.jnosql.demo.key-value